### PR TITLE
Streamline weekly stats message

### DIFF
--- a/src/scheduled/weeklyStatistics.ts
+++ b/src/scheduled/weeklyStatistics.ts
@@ -72,13 +72,13 @@ export default {
 
 		// Tags
 		{
-			let tags: any = [];
+			const tags: { [tag: string]: { [subTag: string]: number } } = {};
 
 			threads.forEach(thread => {
 				thread.appliedTags.forEach(tag => {
 					if(!tags[tag])
 					{
-						tags[tag] = [];
+						tags[tag] = {};
 					}
 
 					thread.appliedTags.forEach(subTag => {
@@ -97,16 +97,22 @@ export default {
 
 			for(const tagId in tags)
 			{
-				let localDescription = ""
-				localDescription += `${await getTagName(guild, forum.availableTags, tagId)}: ${tags[tagId][tagId]}\n`;
+				const tagName = await getTagName(guild, forum.availableTags, tagId);
+				let localDescription = `**${tagName}** (${tags[tagId][tagId]})\n`;
 
-				for(const subTagId in tags[tagId])
-				{
-					if(subTagId == tagId)
-						continue;
-					
-					localDescription += `\* ${await getTagName(guild, forum.availableTags, subTagId)}: ${tags[tagId][subTagId]}\n`;
+				/** Sub tags sorted descending by count, excluding tags that show up just once. */
+				const subTags = Object.entries(tags[tagId])
+					.sort(([, countA],[, countB]) => countB - countA)
+					.filter(([subTagId, count]) => subTagId !== tagId && count > 1);
 
+				if (subTags.length) {
+					const subDescriptions = []
+					for(const [id, count] of subTags)
+					{
+						const subTagName = await getTagName(guild, forum.availableTags, id);
+						subDescriptions.push(`${subTagName} (${count})`);
+					}
+					localDescription += `+ ${subDescriptions.join(' / ')}\n`;
 				}
 
 				localDescription += "\n";


### PR DESCRIPTION
Reworks the weekly statistics message reporting support thread tag usage to follow this more compact format:

<img width="335" alt="Discord message showing some emojis and tag names in two lines" src="https://github.com/withastro/houston-bot/assets/357379/72ea41f7-a49d-44c8-b93e-8a6cb481c368">

Instead of making it “top 3”, this filters out any sub-tags that only occur once, so in theory there could be more than 3 (“Vite” for example in one recent run would have shown 8 sub-tags).

cc @mandar1jn — don’t see any testing instructions in this repo, so would love some guidance or a quick test run if you have time.