### PR TITLE
Fix emoji not displaying in PTAL description when using the `other` field

### DIFF
--- a/src/commands/ptal.ts
+++ b/src/commands/ptal.ts
@@ -336,7 +336,7 @@ const generateReplyFromInteraction = async (
 			break;
 		}
 
-		content += `${GetEmojiFromURL(urlObject, interaction, env)} `;
+		content += `${await GetEmojiFromURL(urlObject, interaction, env)} `;
 		content += `<${urlObject.href}>\n`;
 	}
 


### PR DESCRIPTION
We weren't awaiting the emoji promise