### PR TITLE
Add `/tweet` command

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,6 +3,7 @@ import { default as AskCommand } from './ask.js';
 import { default as DocsCommand } from './docs.js';
 import { default as IssueCommand } from './issue.js';
 import { default as PTALCommand } from './ptal.js';
+import { default as TweetCommand } from './tweet.js';
 // import {default as RetriggerStatisticsCommand} from "./retriggerStatistics";
 
 type CommandList = {
@@ -14,6 +15,7 @@ const commandList: CommandList = {
 	docs: DocsCommand,
 	issue: IssueCommand,
 	ptal: PTALCommand,
+	tweet: TweetCommand,
 	//"retrigger-statistics": RetriggerStatisticsCommand
 };
 

--- a/src/commands/tweet.ts
+++ b/src/commands/tweet.ts
@@ -30,9 +30,6 @@ const messages = [
 ];
 
 const ROLE_TWEET_SQUAD = `<@&1130995247523049522>`;
-// const PERMISSION_MENTION_EVERYONE = 1 << 17;
-
-// TODO: this must be scoped to core!
 const command: Command = {
 	data: new SlashCommandBuilder().setName('tweet').setDescription(`🪄 Summon the tweet squad!`),
 	async execute(client) {

--- a/src/commands/tweet.ts
+++ b/src/commands/tweet.ts
@@ -1,0 +1,48 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { Command } from '../types';
+import { random } from '../utils/helpers.js';
+
+const messages = [
+    `@role is here to save the day! 🫡`,
+    `🐚 @role... assemble!`,
+	`🚨 @role ASSEMBLEEEEEEEEEEE! 🚨`,
+	`@role is here to save the day! 🫡`,
+	`🥺 Help us @role, you're our only hope`,
+	`🪄 @role has been summoned.`,
+	`@role—the platform formerly known as Twitter beckons! 🐦`,
+	`🦣 The fediverse calls, @role! I guess we're still doing Twitter, too...`,
+	`@role, your superior posting abilities are required! 🏆🐐`,
+	`@role has been training for this moment their entire life 💪`,
+	`🔮 Long has the prophecy foretold such a day... only @role can save us now.`,
+	`👋 heyyyyy @role`,
+	`👀 @role... help?`,
+	`Let's Get That Money, @role! 💰🤑🫰`,
+	`How do you do, fellow @role members? 🛹👨‍🦳`,
+	`@role time to _yeet a tweet_ 💀`,
+	`🐸 It is tweet time, my @role-ies.`,
+	`@role—let us post 🙏`,
+	`✨ Your time to shine, @role!`,
+	`We believe in you, @role 👌`,
+	`@role—believe in yourself and all posts are possible 🧠`,
+	`Has anybody seen @role around here? 👀`,
+	`🚨 \`ALERT!\` 🚨 \`ALERT!\` 🚨 \`ALERT!\` 🚨\n**THIS IS A POSTING EMERGENCY!**\n\n(cc @role)`,
+	`No pressure @role, but **THIS** is the **MOST IMPORTANT POST** of **ALL TIME**! 😅`,
+];
+
+const ROLE_TWEET_SQUAD = `<@&1130995247523049522>`;
+// const PERMISSION_MENTION_EVERYONE = 1 << 17;
+
+// TODO: this must be scoped to core!
+const command: Command = {
+	data: new SlashCommandBuilder().setName('tweet').setDescription(`🪄 Summon the tweet squad!`),
+	async execute(client) {
+		const role = ROLE_TWEET_SQUAD;
+		const message = random(messages).replaceAll('@role', role);
+
+		return client.reply({
+			content: message,
+		});
+	},
+};
+
+export default command;


### PR DESCRIPTION
We have a goofy little `!tweet` command for `@core` that's powered by MEE6. All it does is ping the `@tweet-squad` role. I don't like MEE6 so I want to migrate away from it.

Thought it would be fun to move this one over and add some funny messages.

TODO:
- I'm struggling to test this locally
- I'm unsure how to scope the command to certain permissions. This should be accessible only to `@core`, so maybe the ability to use `@everyone` is the most similar?