### PR TITLE
Add staging, production environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 dist
 node_modules
 .wrangler
-.dev.vars
+*.vars
+!*.vars.example

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,9 +4,16 @@ main = "./src/index.ts"
 compatibility_date = "2023-11-08"
 
 node_compat = true
-
 workers_dev = false
+vars = { ENVIRONMENT = "dev" }
+
+[env.staging]
+route = "staging.houstonbot.dev"
+vars = { ENVIRONMENT = "staging" }
+
+[env.production]
 routes = [{ pattern = "houstonbot.dev", custom_domain = true }]
+vars = { ENVIRONMENT = "production" }
 
 # Variable bindings. These are arbitrary, plaintext strings (similar to environment variables)
 # Note: Use secrets to store sensitive data.


### PR DESCRIPTION
- Sets default environment to development, not hooked up to a domain
- Adds a `staging` environment that maps to `staging.houstonbot.dev`
  - Staging will have its own Discord bot for testing in other servers
- Adds a `production` environment that maps to `houstonbot.dev`
- Allows CI to deploy to different environments.
  - Only `main` will be allowed to deploy to `production`

![Two Discord bots named Houston and Houston (Staging)](https://github.com/withastro/houston-discord/assets/7118177/e05b3a68-305d-4cc1-bfa4-82260e9c47ba)
