### PR TITLE
Disallow `@everyone` and `@here` mentions for `/ptal`

### DIFF
--- a/src/commands/ptal.ts
+++ b/src/commands/ptal.ts
@@ -419,6 +419,9 @@ const command: Command = {
 				await rest.patch(Routes.webhookMessage(client.env.DISCORD_CLIENT_ID, client.interaction.token, '@original'), {
 					body: {
 						type: InteractionResponseType.UpdateMessage,
+						allowed_mentions: {
+							parse: ["users", "roles"],
+						},
 						...reply,
 					},
 				});

--- a/src/commands/tweet.ts
+++ b/src/commands/tweet.ts
@@ -38,6 +38,9 @@ const command: Command = {
 
 		return client.reply({
 			content: message,
+			allowed_mentions: {
+				parse: ["roles"],
+			}
 		});
 	},
 };


### PR DESCRIPTION
- `/ptal` should not allow `@everyone` or `@here` mentions, but user and role mentions are valid
- `/tweet` should allow only role mentions