### PR TITLE
feat(ptal): make github arg first

### DIFF
--- a/src/commands/ptal.ts
+++ b/src/commands/ptal.ts
@@ -373,10 +373,10 @@ const command: Command = {
 		.setName('ptal')
 		.setDescription('Open a Please Take a Look (PTAL) request')
 		.addStringOption((option) =>
-			option.setName('description').setDescription('A short description of the PTAL request').setRequired(true)
+			option.setName('github').setDescription('A link to a GitHub pull request').setRequired(true)
 		)
 		.addStringOption((option) =>
-			option.setName('github').setDescription('A link to a GitHub pull request').setRequired(true)
+			option.setName('description').setDescription('A short description of the PTAL request').setRequired(true)
 		)
 		.addStringOption((option) =>
 			option.setName('deployment').setDescription('A link to a deployment related to the PTAL').setRequired(false)


### PR DESCRIPTION
Context on [Discord](https://discord.com/channels/830184174198718474/1172564599682383903/1185286607457226913):

> Other request, could it be possible to make the github arg first? idk how others are doing but I usually copy the url, go to discord and call the ptal command so it would be a little improvement to be able to paste the gh link straight away