### PR TITLE
Add "Files" button on `/ptal` command

### DIFF
--- a/src/commands/ptal.ts
+++ b/src/commands/ptal.ts
@@ -216,6 +216,15 @@ const generateReplyFromInteraction = async (
 			.setURL(url);
 		components.push(githubLink);
 
+		let urlFiles = `https://github.com/${pr_info.owner}/${pr_info.repo}/pull/${pr_info.pull_number}/files`;
+
+		let githubFilesLink = new ButtonBuilder()
+		    .setEmoji({ name: '�', animated: false, id: undefined })
+			.setLabel('Files')
+			.setStyle(ButtonStyle.Link)
+			.setURL(urlFiles);
+		components.push(githubLink);
+
 		try {
 			let pr = await octokit.rest.pulls.get(pr_info);
 			embed.setAuthor({ name: pr.data.user.login, iconURL: `https://github.com/${pr.data.user.login}.png` });


### PR DESCRIPTION
## Why ?
Because it's more simple and fast to see files directly for review. At this moment, for an review, we need to click on the only available button "View on GitHub", wait for it to load, and click on Files.

## Information
The emoji at line 222 is 📁 (a opened folder)

## Preview
![Preview of the /ptal command with Files button](https://github.com/withastro/houston-discord/assets/14293805/5f8f2afb-7a86-4320-b0ea-55216854f460)
 