### PR TITLE
fix: tiny typo in `/solved` command

### DIFF
--- a/src/commands/solved.ts
+++ b/src/commands/solved.ts
@@ -10,7 +10,7 @@ const command: Command = {
 		const embed = getDefaultEmbed()
 			.setTitle('If your issue is resolved, please help by doing the following two steps:')
 			.setDescription(
-				'1. From the ellipses (3-dot menu) in the top-right corner of the post (not the first message), edit the tags to include the Solved tag.\n2. From the same ellipses, select Close Post.\nYour post will still be available to search and can be re-opened simply by replying in it. Closing a post moves it down with older posts, so we can more easily focus on issues that still need to be resovled.\nThank you for your help!'
+				'1. From the ellipses (3-dot menu) in the top-right corner of the post (not the first message), edit the tags to include the Solved tag.\n2. From the same ellipses, select Close Post.\nYour post will still be available to search and can be re-opened simply by replying in it. Closing a post moves it down with older posts, so we can more easily focus on issues that still need to be resolved.\nThank you for your help!'
 			);
 
 		return client.reply({


### PR DESCRIPTION
I just spotted a tiny typo in the output of the `/solved` command: `resovled` > `resolved`, so here the fix!