### PR TITLE
docs: fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ git clone https://github.com/withastro/houston-discord
 pnpm install
 ```
 
-After having cloned the repository and having all dependencies installed, you'll want to create a file for your enviroment variables. To do this, make a copy of `.dev.vars.example` and rename that to `.dev.vars`. To run the bot locally, you will need to create a discord bot. There are plent of guides online on how to do this.
+After having cloned the repository and having all dependencies installed, you'll want to create a file for your environment variables. To do this, make a copy of `.dev.vars.example` and rename that to `.dev.vars`. To run the bot locally, you will need to create a discord bot. There are plenty of guides online on how to do this.
 
-After you have created your bot, set `DISCORD_TOKEN`, `DISCORD_CLIENT_ID` and `DISCORD_PUBLIC_KEY` in your newly created `.dev.vars` file. If you want to use commands that require any other enviroment variables, remove the comment and set those values too.
+After you have created your bot, set `DISCORD_TOKEN`, `DISCORD_CLIENT_ID` and `DISCORD_PUBLIC_KEY` in your newly created `.dev.vars` file. If you want to use commands that require any other environment variables, remove the comment and set those values too.
 
 ## Registering commands
 
@@ -25,6 +25,6 @@ First, you will want to run the command `pnpm dev`. This will start a local inst
 
 After you have your bot running, you will need a service to forward that port to the internet. You could use ngrok, cloudflare tunnels or any other port forwarding utility for this.
 
-Finally, after you have a publically accessible URL for your local instance, go to the developer portal and set the `INTERACTIONS ENDPOINT URL`. If Discord successfully allows you to save the URL, you are good to go.
+Finally, after you have a publicly accessible URL for your local instance, go to the developer portal and set the `INTERACTIONS ENDPOINT URL`. If Discord successfully allows you to save the URL, you are good to go.
 
 Depending on your port forwarding utility, you may need to repeat the last step every time you stop it or restart your computer.


### PR DESCRIPTION
plent->plenty, enviroment->environment, publically->publicly.